### PR TITLE
Fix Add Contacts though AddContactModal

### DIFF
--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -506,8 +506,8 @@ export default createStore({
       state.rateLimitError = null;
       if (this.state.socket.isConnected
         && contact.name !== "" && contact.phone !== "") {
-          if(typeof state.currentChat !== "undefined" &&
-            this.state.currentChat.Tel === contact.phone){
+          if(this.state.currentChat !== null
+            && this.state.currentChat.Tel === contact.phone){
             this.commit("SET_CURRENT_CHAT_NAME", contact.name);
           }
         const message = {
@@ -581,8 +581,8 @@ export default createStore({
     editContact(state, data) {
       state.rateLimitError = null;
       if (this.state.socket.isConnected) {
-        if(typeof state.currentChat !== "undefined" &&
-          this.state.currentChat.Tel === data.contact.Tel){
+        if(this.state.currentChat !== null
+          && this.state.currentChat.Tel === data.contact.Tel){
           this.commit("SET_CURRENT_CHAT_NAME", data.contact.Name);
         }
         const message = {


### PR DESCRIPTION
This addresses only step 5 from https://github.com/nanu-c/axolotl/issues/576 (Adding contacts through the add contact modal)

In my local testing, I do not have any existing chats, and I believe this unsafe reference to `this.state.currentChat.Tel` is breaking the addContact flow. Making this change locally on my device (Mobian/PinePhone) allowed me to successfully add contacts.

I suspect if I knew how to run axolotl in debug mode to get output from vuejs, this would have been easier to track down. Any tips for that would be appreciated.