### PR TITLE
Add clickable json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,3 @@ dist
 axolotl.code-workspace
 libzkgroup.so
 libzkgroup*.so
-go/*
-config.textsecure.nanuc


### PR DESCRIPTION
When building with clickable, I get an error about not having specified the clickable builder. This needs to be done in clickable.json file. This PR will add this file to the repo with some more content I picked from the old master branch clickable.json. At least with this file `clickable` works again. Not sure if all of this is 100% needed. I tried to clear up the old "ignore" list.