### PR TITLE
Adjust CI clickable packaging

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -176,14 +176,14 @@ jobs:
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:
-          args: clickable --verbose clean build-libs crayfish
+          args: clickable --config clickable.yaml --verbose clean build-libs crayfish
 
       - name: Build clickable (armhf)
         uses: docker://clickable/ci-16.04-armhf:16.04.5
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:
-          args: clickable --verbose clean build
+          args: clickable --config clickable.yaml --verbose clean build
 
       - name: Upload the built clickable artifact (armhf)
         uses: actions/upload-artifact@v2
@@ -219,14 +219,14 @@ jobs:
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:
-          args: clickable --verbose clean build-libs crayfish
+          args: clickable --config clickable.yaml --verbose clean build-libs crayfish
 
       - name: Build clickable (arm64)
         uses: docker://clickable/ci-16.04-arm64:16.04.5
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:
-          args: clickable --verbose clean build
+          args: clickable --config clickable.yaml --verbose clean build
 
       - name: Upload the built clickable artifact (amd64)
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
I cannot find any documentation regarding the clickable --libs flag, it seems that the way to go is build-libs?

This MR could be seen as a continuation of the discussion in https://github.com/nanu-c/axolotl/pull/596.

I am not sure if the build and the build-libs should/can be done in one go either. 

This MR is more to open for a discussion and to make our pipelines functional again.