### PR TITLE
axolotl needs at least clickable 7.0.0 / fix clickable ci

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -172,7 +172,7 @@ jobs:
           mv libzkgroup_linux_armv7_v0.8.8.so $GITHUB_WORKSPACE/lib/libzkgroup_linux_armv7.so
 
       - name: Build clickable (armhf)
-        uses: docker://clickable/ci-dev-16.04-armhf:16.04.5
+        uses: docker://clickable/ci-dev-16.04-armhf:latest
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:
@@ -208,7 +208,7 @@ jobs:
             mv libzkgroup_linux_aarch64_v0.8.8.so $GITHUB_WORKSPACE/lib/libzkgroup_linux_aarch64.so
 
       - name: Build clickable (arm64)
-        uses: docker://clickable/ci-dev-16.04-arm64:16.04.5
+        uses: docker://clickable/ci-dev-16.04-arm64:latest
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:


### PR DESCRIPTION
@bhdouglas proposed to use the latest clickable dev container.