### PR TITLE
Add usefull notes to install doc for fedora and bare

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -321,7 +321,7 @@ I also had to install the breezy package to get the bzr command.
 
 **Tooling**
 
-This requires `make`, `go`, `nodejs`, `cargo` and `npm` to be installed locally.
+This requires `make`, `go`, `nodejs`, `cargo`,  `rust` and `npm` to be installed locally.
 For the required versions, see [go.mod](../go.mod) and [package.json](../axolotl-web/package.json)
 
 **Build and Install**


### PR DESCRIPTION
I did some bug triage and in #502 there was a useful hint for building with fedora. I also noted, that this file is still missing the rust part but i don't know which package needs what.