### PR TITLE
Install desired rust version in Clickable image

### DIFF
--- a/clickable.yaml
+++ b/clickable.yaml
@@ -37,6 +37,7 @@ libraries:
   crayfish:
     builder: rust
     src_dir: crayfish
+    rust_channel: 1.55.0
   nodejs_deps:
     image_setup:
       run:


### PR DESCRIPTION
We have a rust-toolchain.toml specifying Rust 1.55.0. Therefore we should install it in the Clickable image, too.

In order to test this make sure to have the latest Clickable updates from the `dev` channel, as you need [this patch](https://gitlab.com/clickable/clickable/-/merge_requests/441).