### PR TITLE
Add FormFactor settings to desktop files

### DIFF
--- a/appimage/AppDir/axolotl.desktop
+++ b/appimage/AppDir/axolotl.desktop
@@ -5,3 +5,5 @@ Type=Application
 Comment=A signal client, AppImage version
 Categories=Network;InstantMessaging;Chat;
 Icon=axolotl
+X-KDE-FormFactor=desktop;tablet;handset;
+X-Purism-FormFactor=Workstation;Mobile; 

--- a/click/textsecure.desktop
+++ b/click/textsecure.desktop
@@ -8,3 +8,5 @@ Type=Application
 X-Ubuntu-Touch=true
 X-Ubuntu-Default-Department-ID=communication
 X-Ubuntu-Splash-Color=#2090ea
+X-KDE-FormFactor=desktop;tablet;handset;
+X-Purism-FormFactor=Workstation;Mobile; 

--- a/deb/axolotl.desktop
+++ b/deb/axolotl.desktop
@@ -9,3 +9,5 @@ Icon=axolotl.png
 Terminal=false
 Categories=Network;Chat;InstantMessaging
 StartupWMClass=axolotl
+X-KDE-FormFactor=desktop;tablet;handset;
+X-Purism-FormFactor=Workstation;Mobile; 

--- a/flatpak/qt/org.nanuc.Axolotl.desktop
+++ b/flatpak/qt/org.nanuc.Axolotl.desktop
@@ -8,3 +8,5 @@ Comment=A signal client, flatpak version
 Terminal=false
 Categories=Network;InstantMessaging;Chat;
 Icon=org.nanuc.Axolotl
+X-KDE-FormFactor=desktop;tablet;handset;
+X-Purism-FormFactor=Workstation;Mobile; 

--- a/flatpak/web/org.nanuc.Axolotl.desktop
+++ b/flatpak/web/org.nanuc.Axolotl.desktop
@@ -8,3 +8,5 @@ Comment=A signal client, flatpak version
 Terminal=false
 Categories=Network;InstantMessaging;Chat;
 Icon=org.nanuc.Axolotl
+X-KDE-FormFactor=desktop;tablet;handset;
+X-Purism-FormFactor=Workstation;Mobile; 

--- a/scripts/axolotl.desktop
+++ b/scripts/axolotl.desktop
@@ -7,3 +7,5 @@ Icon=axolotl
 Comment=A signal client
 Categories=Network;InstantMessaging;Chat;
 Terminal=false
+X-KDE-FormFactor=desktop;tablet;handset;
+X-Purism-FormFactor=Workstation;Mobile; 

--- a/snap/gui/axolotl.desktop
+++ b/snap/gui/axolotl.desktop
@@ -8,3 +8,5 @@ Comment=A signal client, snap version
 Terminal=false
 Categories=Network;InstantMessaging;Chat;
 Icon=${SNAP}/meta/gui/axolotl.png
+X-KDE-FormFactor=desktop;tablet;handset;
+X-Purism-FormFactor=Workstation;Mobile; 


### PR DESCRIPTION
Without a properly set FormFactor value, certain shells, like
the Phosh (Wayland shell for GNOME) does not show the
the app, unless the "Show only adaptive apps" radio button
is unticked. Since the available GUIs of axolotl can be considered
adaptive, we should declare the form factor to be mobile ready.