### PR TITLE
change tsdevice for sgn in linking signal desktop

### DIFF
--- a/app/webserver/webserver.go
+++ b/app/webserver/webserver.go
@@ -282,8 +282,8 @@ func wsReader(conn *websocket.Conn) {
 			json.Unmarshal([]byte(p), &addDeviceMessage)
 			log.Println("[axolotl] add device " + addDeviceMessage.Url)
 			if addDeviceMessage.Url != "" {
-				if strings.Contains(addDeviceMessage.Url, "sgn") {
-					fmt.Printf("found sgn")
+				if strings.Contains(addDeviceMessage.Url, "sgnl") {
+					fmt.Printf("found sgnl")
 					store.AddDevice(addDeviceMessage.Url)
 				}
 			}

--- a/click/textsecure.url-dispatcher
+++ b/click/textsecure.url-dispatcher
@@ -1,5 +1,5 @@
 [
     {
-        "protocol": "sgn"
+        "protocol": "sgnl"
     }
 ]


### PR DESCRIPTION
Signal changed the signal desktop urls from tsdevice:// to sgn://. This pr respects this