### PR TITLE
version 1.0.7

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -18,7 +18,7 @@ import (
 
 const AppName = "textsecure.nanuc"
 
-const AppVersion = "1.0.6"
+const AppVersion = "1.0.7"
 
 // Do not allow sending attachments larger than 100M for now
 var MaxAttachmentSize int64 = 100 * 1024 * 1024

--- a/appimage/AppDir/axolotl.appdata.xml
+++ b/appimage/AppDir/axolotl.appdata.xml
@@ -29,6 +29,9 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="1.0.7" date="2021-10-28">
+            <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.7</url>
+        </release>
         <release version="1.0.6" date="2021-10-26">
             <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.6</url>
         </release>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.7 (Okt 28 2021) 
+------------------------------------
+* Fix deleting chats (nuehm-arno)
+* Update electron version (Ferenc-)
+* Explicitly set ozone platform to Wayland for electron when needed (Ferenc-)
+* Fix clickable zkgroup copy error (nanu-c)
+* Explicitly set clickable-rust-version (jonnius)
+
 1.0.6 (Okt 26 2021) 
 ------------------------------------
 * Fix signal desktop linking by change signal desktop link url (nanu-c)

--- a/flatpak/org.nanuc.Axolotl.appdata.xml
+++ b/flatpak/org.nanuc.Axolotl.appdata.xml
@@ -29,6 +29,9 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="1.0.7" date="2021-10-28">
+            <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.7</url>
+        </release>
         <release version="1.0.6" date="2021-10-26">
             <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.6</url>
         </release>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "textsecure.nanuc",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "A Signal compatible messaging client for Ubuntu phones",
     "title": "Axolotl",
     "architecture": "@CLICK_ARCH@",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ grade: stable
 confinement: strict
 base: core20
 icon: snap/gui/axolotl.png
-version: "1.0.6"
+version: "1.0.7"
 architectures:
   - build-on: amd64
   - build-on: arm64


### PR DESCRIPTION
1.0.7 (Okt 28 2021) 
------------------------------------
* Fix deleting chats (nuehm-arno)
* Update electron version (Ferenc-)
* Explicitly set ozone platform to Wayland for electron when needed (Ferenc-)
* Fix clickable zkgroup copy error (nanu-c)
* Explicitly set clickable-rust-version (jonnius)