### PR TITLE
Dependabot Flatpak sources

### DIFF
--- a/.github/workflows/dependabot-post.yml
+++ b/.github/workflows/dependabot-post.yml
@@ -19,9 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        # Check out correct branch also for PRs from forks
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
         # Fetch whole history as we want to commit and push
         fetch-depth: 0
     

--- a/.github/workflows/dependabot-post.yml
+++ b/.github/workflows/dependabot-post.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # Using an SSH deploy key to allow running workflows triggered by push event
+        # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+        ssh-key: '${{ secrets.DEPENDABOT_SSH_KEY }}'
         # Fetch whole history as we want to commit and push
         fetch-depth: 0
     

--- a/.github/workflows/dependabot-post.yml
+++ b/.github/workflows/dependabot-post.yml
@@ -13,6 +13,10 @@ concurrency:
 jobs:
   flatpak-sources-update:
     name: Update Flatpak sources
+    # Avoid infinit loops of this workflow pushing and triggering another workflow
+    # We do want to run the other workflows to build and test but do not want to run this one again.
+    # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#prevent-infinite-loop-when-using-a-personal-access-token
+    if: github.actor == 'dependabot'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
GitHub does not trigger workflows for events triggered with the default `GITHUB_TOKEN`.

Therefore, I created an SSH deploy key to push the changes but also made sure to avoid infinite loops by only running for the `dependabot` actor.