### PR TITLE
Update clickable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -282,7 +282,7 @@ jobs:
         uses: ChristopherHX/conditional@b4a9649204f81002ec9a4ef7d4bf7d6b2ab7fa55
         with:
           step: |
-            uses: docker://clickable/ci-20.04-${{ matrix.arch }}:8.0.1
+            uses: docker://clickable/ci-20.04-${{ matrix.arch }}:8.2.0
             with:
               args: clickable build --verbose -a ${{ matrix.arch }}
 

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 8.0.1
+clickable_minimum_required: 8.2.0
 
 builder: rust
 rust_channel: 1.72.1

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,7 +1,7 @@
 clickable_minimum_required: 8.2.0
 
 builder: rust
-rust_channel: 1.72.1
+rust_channel: stable
 build_args: --features ut
 
 dependencies_host:


### PR DESCRIPTION
This unblocks more Rust dependency upgrades as it provides the latest stable Rust toolchain also in the Clickable image.