### PR TITLE
Add job to test if all build jobs succeeded

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,3 +10,17 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+
+  # Check if all important jobs passed
+  # This can be used as required status for branch protection rules.
+  pr-ok:
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+      - name: All tests ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
This can be used as required status for branch protection rules.