### PR TITLE
Enable auto-approve for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -54,6 +54,18 @@ jobs:
           # Do not overwrite in case our version is outdated
           push_options: "--force-with-lease"
 
+  auto-approve:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Auto approve Dependabot PRs
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
   auto-merge:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
There regularly are lots of dependency upgrades and manually approving all of them is quite work intense. Merging still requires all workflows to pass so it should be safe.