### PR TITLE
Use GitHub hosted ARM runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,8 @@ jobs:
           - arch: x86_64
             runner: ubuntu-latest
           - arch: aarch64
-            runner: ARM64
+            # TODO use ubuntu-latest-arm tag once available
+            runner: ubuntu-24.04-arm
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
     runs-on: ${{ matrix.variant.runner }}


### PR DESCRIPTION
Ubuntu now offers [free hosted arm64 runners for public repositories](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/). This allows us to get rid of maintaining our own arm64 runner and also offers running multiple PRs in parallel with multiple runners hosted by GitHub.