### PR TITLE
Fix tauri-cli installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,14 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: tauri-cli
+          # Specifically choose host arch
+          # as actions-rust-lang/setup-rust-toolchain flag "override" defaults to true and sets the installed toolchain as the default
+          args: --target x86_64-unknown-linux-gnu
+        env:
+          # Reset pkgconfig env configured previously to compile for host
+          PKG_CONFIG_ALLOW_CROSS: "0"
+          PKG_CONFIG_PATH: "/usr/lib/pkgconfig"
+          PKG_CONFIG_SYSROOT_DIR: "/"
 
       - name: Build deb package
         run: cargo tauri build --ci --target aarch64-unknown-linux-gnu --features tauri --bundles deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,6 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: tauri-cli
-          version: '^2.0.0-rc'
 
       - name: Build deb package
         run: cargo tauri build --ci --features tauri --bundles deb


### PR DESCRIPTION
- Use latest version also for x86 as this was already done for arm64 in 9a59f1111bc5fe471f6d7b25cd99393093bb4a43
- Target host platform as this is run on the host as part of the build process